### PR TITLE
Add JWT token authentication to socket connections

### DIFF
--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -1,4 +1,21 @@
 import { io, Socket } from 'socket.io-client'
+import { useAuthStore } from '@/store/authStore'
+
+function getSocketAuthToken(): string | undefined {
+  if (typeof window === 'undefined') return undefined
+  try {
+    const state = (useAuthStore as any).getState ? (useAuthStore as any).getState() : null
+    const token = state?.session?.accessToken as string | undefined
+    if (token && typeof token === 'string' && token.length > 0) return token
+    const raw = localStorage.getItem('auth-storage')
+    if (!raw) return undefined
+    const parsed = JSON.parse(raw)
+    const persisted = parsed?.state?.session?.accessToken as string | undefined
+    if (persisted && typeof persisted === 'string' && persisted.length > 0) return persisted
+  } catch (e) {
+  }
+  return undefined
+}
 
 export interface SocketConnectionConfig {
   accessCode?: string
@@ -62,6 +79,7 @@ export class SocketService {
         reconnectionAttempts: 5,
         reconnectionDelay: 1000,
         timeout: 20000,
+        auth: (function(){ const t = getSocketAuthToken(); return t ? { token: t } : undefined })(),
         query: config.accessCode ? {
           accessCode: config.accessCode
         } : {}


### PR DESCRIPTION
## Purpose

The user requested to add JWT token authentication to socket connections to ensure secure communication. They wanted the socket connection to include the user's authentication token in the auth configuration, similar to the example they provided.

## Code changes

- **Added token retrieval function**: Created `getSocketAuthToken()` helper function that attempts to get the JWT token from auth store state or localStorage fallback
- **Enhanced socket configuration**: Modified both `SocketService` and `WebSocketClient` classes to include `auth` parameter with the user's JWT token when establishing socket connections
- **Graceful fallback**: Implemented error handling and fallback mechanisms to retrieve the token from multiple sources (store state and localStorage)
- **SSR compatibility**: Added check for browser environment to prevent server-side execution issues

The changes ensure that all socket connections now automatically include the user's authentication token for secure communication with the server.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 63`

🔗 [Edit in Builder.io](https://builder.io/app/projects/799d25b5141b49db88f7670da4a78ae3/cosmos-studio)

👀 [Preview Link](https://799d25b5141b49db88f7670da4a78ae3-cosmos-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>799d25b5141b49db88f7670da4a78ae3</projectId>-->
<!--<branchName>cosmos-studio</branchName>-->