### PR TITLE
Add booking management pages for users, creators, and admin

### DIFF
--- a/src/app/admin/bookings/page.tsx
+++ b/src/app/admin/bookings/page.tsx
@@ -1,0 +1,147 @@
+"use client"
+
+import React from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { AlertTriangle } from 'lucide-react'
+import { bookingApi, type Booking, type BookingStatus, type BookingType } from '@/lib/api/booking'
+import BookingList from '@/components/booking/BookingList'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/hooks/use-toast'
+
+const statusOptions: { value: 'all' | BookingStatus; label: string }[] = [
+  { value: 'all', label: 'Tất cả trạng thái' },
+  { value: 'pending', label: 'Chờ xác nhận' },
+  { value: 'confirmed', label: 'Đã xác nhận' },
+  { value: 'in_progress', label: 'Đang diễn ra' },
+  { value: 'completed', label: 'Hoàn tất' },
+  { value: 'cancelled', label: 'Đã hủy' },
+  { value: 'no_show', label: 'Không tham dự' },
+]
+
+const typeOptions: { value: 'all' | BookingType; label: string }[] = [
+  { value: 'all', label: 'Tất cả loại' },
+  { value: 'private_show', label: 'Private show' },
+  { value: 'private_chat', label: 'Private chat' },
+  { value: 'cam2cam', label: 'Cam2Cam' },
+  { value: 'byshot', label: 'Gói theo shot' },
+  { value: 'byhour', label: 'Theo giờ' },
+]
+
+export default function AdminBookingsPage() {
+  const [status, setStatus] = React.useState<'all' | BookingStatus>('all')
+  const [type, setType] = React.useState<'all' | BookingType>('all')
+  const [bookings, setBookings] = React.useState<Booking[]>([])
+  const [loading, setLoading] = React.useState(false)
+  const [actionLoading, setActionLoading] = React.useState<Record<number, boolean>>({})
+  const { toast } = useToast()
+
+  const fetchData = React.useCallback(async () => {
+    setLoading(true)
+    try {
+      // Hiện tại lib/api/booking.ts chưa có API cho admin để lấy tất cả booking.
+      // Tạm thời dùng getCreatorBookings() để hiển thị nếu admin là creator (thường sẽ rỗng).
+      const opts = status === 'all' ? undefined : { status }
+      const res = await bookingApi.getCreatorBookings(opts)
+      if (res.success && res.data) {
+        const list = res.data.bookings || []
+        setBookings(type === 'all' ? list : list.filter(b => b.type === type))
+      } else {
+        setBookings([])
+        if (res.error) toast({ title: 'Lỗi', description: res.error, variant: 'destructive' })
+      }
+    } catch (e: any) {
+      toast({ title: 'Lỗi', description: e?.message || 'Không thể tải danh sách', variant: 'destructive' })
+    } finally {
+      setLoading(false)
+    }
+  }, [status, type, toast])
+
+  React.useEffect(() => { fetchData() }, [fetchData])
+
+  const withAction = async (id: number, fn: () => Promise<any>, successMsg: string) => {
+    setActionLoading(prev => ({ ...prev, [id]: true }))
+    try {
+      const res = await fn()
+      if (res.success) {
+        toast({ title: successMsg })
+        fetchData()
+      } else {
+        toast({ title: 'Thất bại', description: res.error || res.message || 'Có lỗi xảy ra', variant: 'destructive' })
+      }
+    } catch (e: any) {
+      toast({ title: 'Lỗi', description: e?.message || 'Có lỗi xảy ra', variant: 'destructive' })
+    } finally {
+      setActionLoading(prev => ({ ...prev, [id]: false }))
+    }
+  }
+
+  const handleAccept = (id: number) => withAction(id, () => bookingApi.acceptBooking(id), 'Đã chấp nhận booking')
+  const handleReject = (id: number) => {
+    const reason = window.prompt('Lý do từ chối (tối thiểu 10 ký tự):') || ''
+    if (reason.trim().length < 10) {
+      toast({ title: 'Lý do không hợp lệ', variant: 'destructive' })
+      return
+    }
+    return withAction(id, () => bookingApi.rejectBooking(id, reason.trim()), 'Đã từ chối booking')
+  }
+  const handleCancel = (id: number) => {
+    const reason = window.prompt('Lý do hủy (tuỳ chọn, <= 500 ký tự):') || undefined
+    return withAction(id, () => bookingApi.cancelBooking(id, reason), 'Đã hủy booking')
+  }
+  const handleComplete = (id: number) => withAction(id, () => bookingApi.completeBooking(id), 'Đã hoàn tất booking')
+
+  return (
+    <div className="p-6">
+      <div className="mx-auto max-w-6xl">
+        <Card>
+          <CardHeader className="space-y-2">
+            <CardTitle className="text-xl">Quản lý Booking (Admin)</CardTitle>
+            <CardDescription className="flex items-start gap-2 text-amber-600">
+              <AlertTriangle className="h-4 w-4 mt-0.5" />
+              <span>Hiện chưa có API dành cho Admin để xem tất cả booking trong lib/api/booking.ts. Cần bổ sung endpoint backend (ví dụ: /bookings/admin) và hàm getAllBookings(). Trang hiện hiển th�� dữ liệu nếu tài khoản admin đồng thời là creator.</span>
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="mb-4 flex flex-wrap gap-2">
+              <Select value={status} onValueChange={(v) => setStatus(v as any)}>
+                <SelectTrigger className="w-48">
+                  <SelectValue placeholder="Trạng thái" />
+                </SelectTrigger>
+                <SelectContent>
+                  {statusOptions.map(o => (
+                    <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select value={type} onValueChange={(v) => setType(v as any)}>
+                <SelectTrigger className="w-48">
+                  <SelectValue placeholder="Loại" />
+                </SelectTrigger>
+                <SelectContent>
+                  {typeOptions.map(o => (
+                    <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button variant="secondary" onClick={fetchData} disabled={loading}>Làm mới</Button>
+            </div>
+            {loading ? (
+              <div className="py-10 text-center text-muted-foreground">Đang tải...</div>
+            ) : (
+              <BookingList
+                bookings={bookings}
+                role="admin"
+                onAccept={handleAccept}
+                onReject={handleReject}
+                onCancel={handleCancel}
+                onComplete={handleComplete}
+                loading={actionLoading}
+              />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/app/bookings/page.tsx
+++ b/src/app/bookings/page.tsx
@@ -1,0 +1,142 @@
+"use client"
+
+import React from 'react'
+import { useAuth } from '@/hooks/useAuth'
+import { bookingApi, type Booking, type BookingStatus, type BookingType } from '@/lib/api/booking'
+import BookingList from '@/components/booking/BookingList'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/hooks/use-toast'
+
+const statusOptions: { value: 'all' | BookingStatus; label: string }[] = [
+  { value: 'all', label: 'Tất cả trạng thái' },
+  { value: 'pending', label: 'Chờ xác nhận' },
+  { value: 'confirmed', label: 'Đã xác nhận' },
+  { value: 'in_progress', label: 'Đang diễn ra' },
+  { value: 'completed', label: 'Hoàn tất' },
+  { value: 'cancelled', label: 'Đã hủy' },
+  { value: 'no_show', label: 'Không tham dự' },
+]
+
+const typeOptions: { value: 'all' | BookingType; label: string }[] = [
+  { value: 'all', label: 'Tất cả loại' },
+  { value: 'private_show', label: 'Private show' },
+  { value: 'private_chat', label: 'Private chat' },
+  { value: 'cam2cam', label: 'Cam2Cam' },
+  { value: 'byshot', label: 'Gói theo shot' },
+  { value: 'byhour', label: 'Theo giờ' },
+]
+
+export default function BookingsPage() {
+  const { isAuthenticated, isCreator, isAdmin } = useAuth()
+  const role: 'user' | 'creator' | 'admin' = isAdmin() ? 'admin' : (isCreator() ? 'creator' : 'user')
+  const [status, setStatus] = React.useState<'all' | BookingStatus>('all')
+  const [type, setType] = React.useState<'all' | BookingType>('all')
+  const [bookings, setBookings] = React.useState<Booking[]>([])
+  const [loading, setLoading] = React.useState(false)
+  const [actionLoading, setActionLoading] = React.useState<Record<number, boolean>>({})
+  const { toast } = useToast()
+
+  const fetchData = React.useCallback(async () => {
+    if (!isAuthenticated) return
+    setLoading(true)
+    try {
+      const opts = status === 'all' ? undefined : { status }
+      const res = role === 'creator' || role === 'admin' ? await bookingApi.getCreatorBookings(opts) : await bookingApi.getUserBookings(opts)
+      if (res.success && res.data) {
+        const list = res.data.bookings || []
+        setBookings(type === 'all' ? list : list.filter(b => b.type === type))
+      } else {
+        setBookings([])
+        if (res.error) toast({ title: 'Lỗi', description: res.error, variant: 'destructive' })
+      }
+    } catch (e: any) {
+      toast({ title: 'Lỗi', description: e?.message || 'Không thể tải danh sách', variant: 'destructive' })
+    } finally {
+      setLoading(false)
+    }
+  }, [isAuthenticated, role, status, type, toast])
+
+  React.useEffect(() => { fetchData() }, [fetchData])
+
+  const withAction = async (id: number, fn: () => Promise<any>, successMsg: string) => {
+    setActionLoading(prev => ({ ...prev, [id]: true }))
+    try {
+      const res = await fn()
+      if (res.success) {
+        toast({ title: successMsg })
+        fetchData()
+      } else {
+        toast({ title: 'Thất bại', description: res.error || res.message || 'Có lỗi xảy ra', variant: 'destructive' })
+      }
+    } catch (e: any) {
+      toast({ title: 'Lỗi', description: e?.message || 'Có lỗi xảy ra', variant: 'destructive' })
+    } finally {
+      setActionLoading(prev => ({ ...prev, [id]: false }))
+    }
+  }
+
+  const handleAccept = (id: number) => withAction(id, () => bookingApi.acceptBooking(id), 'Đã chấp nhận booking')
+  const handleReject = (id: number) => {
+    const reason = window.prompt('Lý do từ chối (tối thiểu 10 ký tự):') || ''
+    if (reason.trim().length < 10) {
+      toast({ title: 'Lý do không hợp lệ', variant: 'destructive' })
+      return
+    }
+    return withAction(id, () => bookingApi.rejectBooking(id, reason.trim()), 'Đã từ chối booking')
+  }
+  const handleCancel = (id: number) => {
+    const reason = window.prompt('Lý do hủy (tuỳ chọn, <= 500 ký tự):') || undefined
+    return withAction(id, () => bookingApi.cancelBooking(id, reason), 'Đã hủy booking')
+  }
+  const handleComplete = (id: number) => withAction(id, () => bookingApi.completeBooking(id), 'Đã hoàn tất booking')
+
+  return (
+    <div className="container py-6">
+      <Card>
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle className="text-xl font-semibold">Quản lý Booking</CardTitle>
+          <div className="flex flex-wrap gap-2">
+            <Select value={status} onValueChange={(v) => setStatus(v as any)}>
+              <SelectTrigger className="w-48">
+                <SelectValue placeholder="Trạng thái" />
+              </SelectTrigger>
+              <SelectContent>
+                {statusOptions.map(o => (
+                  <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={type} onValueChange={(v) => setType(v as any)}>
+              <SelectTrigger className="w-48">
+                <SelectValue placeholder="Loại" />
+              </SelectTrigger>
+              <SelectContent>
+                {typeOptions.map(o => (
+                  <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button variant="secondary" onClick={fetchData} disabled={loading}>Làm mới</Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="py-10 text-center text-muted-foreground">Đang tải...</div>
+          ) : (
+            <BookingList
+              bookings={bookings}
+              role={role}
+              onAccept={handleAccept}
+              onReject={handleReject}
+              onCancel={handleCancel}
+              onComplete={handleComplete}
+              loading={actionLoading}
+            />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/components/booking/BookingList.tsx
+++ b/src/components/booking/BookingList.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import React from 'react'
+import type { Booking, BookingStatus, BookingType } from '@/lib/api/booking'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { cn } from '@/lib/utils'
+
+type RoleKind = 'user' | 'creator' | 'admin'
+
+export interface BookingListProps {
+  bookings: Booking[]
+  role: RoleKind
+  onAccept?: (bookingId: number) => void
+  onReject?: (bookingId: number) => void
+  onCancel?: (bookingId: number) => void
+  onComplete?: (bookingId: number) => void
+  loading?: Record<number, boolean>
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return 'Chưa đặt lịch'
+  const d = new Date(value)
+  const dd = d.toLocaleDateString('vi-VN', { weekday: 'short', day: '2-digit', month: '2-digit', year: 'numeric' })
+  const tt = d.toLocaleTimeString('vi-VN', { hour: '2-digit', minute: '2-digit' })
+  return `${dd} • ${tt}`
+}
+
+function dayKey(value: string | null): string {
+  if (!value) return 'Khác'
+  const d = new Date(value)
+  return d.toISOString().slice(0, 10)
+}
+
+const statusText: Record<BookingStatus, string> = {
+  pending: 'Chờ xác nhận',
+  confirmed: 'Đã xác nhận',
+  in_progress: 'Đang diễn ra',
+  completed: 'Hoàn tất',
+  cancelled: 'Đã hủy',
+  no_show: 'Không tham dự',
+}
+
+const typeText: Record<BookingType, string> = {
+  private_show: 'Private show',
+  private_chat: 'Private chat',
+  cam2cam: 'Cam2Cam',
+  byshot: 'Gói theo shot',
+  byhour: 'Theo giờ',
+}
+
+const statusClass: Record<BookingStatus, string> = {
+  pending: 'bg-yellow-500/10 text-yellow-600',
+  confirmed: 'bg-blue-500/10 text-blue-600',
+  in_progress: 'bg-purple-500/10 text-purple-600',
+  completed: 'bg-green-500/10 text-green-600',
+  cancelled: 'bg-red-500/10 text-red-600',
+  no_show: 'bg-gray-500/10 text-gray-600',
+}
+
+const canAccept = (role: RoleKind, status: BookingStatus) => (role !== 'user') && status === 'pending'
+const canReject = (role: RoleKind, status: BookingStatus) => (role !== 'user') && status === 'pending'
+const canComplete = (role: RoleKind, status: BookingStatus) => (role !== 'user') && (status === 'in_progress' || status === 'confirmed')
+const canCancel = (role: RoleKind, status: BookingStatus) => (status === 'pending' || status === 'confirmed')
+
+export default function BookingList({ bookings, role, onAccept, onReject, onCancel, onComplete, loading }: BookingListProps) {
+  const grouped = React.useMemo(() => {
+    const map = new Map<string, Booking[]>()
+    ;(bookings || []).forEach(b => {
+      const key = dayKey(b.scheduledTime)
+      const arr = map.get(key) || []
+      arr.push(b)
+      map.set(key, arr)
+    })
+    return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b))
+  }, [bookings])
+
+  if (!bookings || bookings.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center text-muted-foreground">Chưa có booking nào</CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {grouped.map(([key, items]) => {
+        const any = items[0]
+        const label = any.scheduledTime ? new Date(any.scheduledTime).toLocaleDateString('vi-VN', { weekday: 'long', day: '2-digit', month: '2-digit', year: 'numeric' }) : 'Khác'
+        return (
+          <Card key={key}>
+            <CardHeader>
+              <CardTitle className="text-base font-semibold">{label}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {items.sort((a, b) => {
+                const ta = a.scheduledTime ? new Date(a.scheduledTime).getTime() : 0
+                const tb = b.scheduledTime ? new Date(b.scheduledTime).getTime() : 0
+                return ta - tb
+              }).map((b, idx) => (
+                <div key={b.id} className="flex flex-col gap-3 rounded-md border p-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge className={cn('capitalize', statusClass[b.status])}>{statusText[b.status]}</Badge>
+                      <Badge variant="secondary">{typeText[b.type]}</Badge>
+                      <span className="text-sm text-muted-foreground">{b.duration} phút</span>
+                    </div>
+                    <div className="mt-1 text-sm font-medium">{formatDate(b.scheduledTime)}</div>
+                    {b.notes ? (
+                      <div className="mt-1 text-sm text-muted-foreground">{b.notes}</div>
+                    ) : null}
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {canAccept(role, b.status) && (
+                      <Button size="sm" onClick={() => onAccept?.(b.id)} disabled={!!loading?.[b.id]}>Chấp nhận</Button>
+                    )}
+                    {canReject(role, b.status) && (
+                      <Button size="sm" variant="destructive" onClick={() => onReject?.(b.id)} disabled={!!loading?.[b.id]}>Từ chối</Button>
+                    )}
+                    {canComplete(role, b.status) && (
+                      <Button size="sm" variant="secondary" onClick={() => onComplete?.(b.id)} disabled={!!loading?.[b.id]}>Hoàn tất</Button>
+                    )}
+                    {canCancel(role, b.status) && (
+                      <Button size="sm" variant="outline" onClick={() => onCancel?.(b.id)} disabled={!!loading?.[b.id]}>Hủy</Button>
+                    )}
+                  </div>
+                </div>
+              ))}
+              <Separator />
+            </CardContent>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
## Purpose
The user requested the creation of booking management pages for different user roles (creator, user, admin) to view booking schedules. The implementation utilizes the existing `lib/api/booking.ts` API to provide role-based booking management functionality.

## Code changes
- **Added `/src/app/bookings/page.tsx`**: Main booking management page that adapts based on user role (user/creator/admin) with filtering by status and type
- **Added `/src/app/admin/bookings/page.tsx`**: Dedicated admin booking management page with note about missing admin-specific API endpoints
- **Added `/src/components/booking/BookingList.tsx`**: Reusable component for displaying bookings with role-based action buttons (accept, reject, cancel, complete)

Key features implemented:
- Role-based access and functionality (user, creator, admin)
- Status and type filtering for bookings
- Action buttons for booking management (accept/reject/cancel/complete)
- Grouped display by date with Vietnamese localization
- Integration with existing booking API and toast notifications
- Responsive design with proper loading states

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 95`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b60ee85bfa2b4d6a8f3adccff5cb49f3/mystic-field)

👀 [Preview Link](https://b60ee85bfa2b4d6a8f3adccff5cb49f3-mystic-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b60ee85bfa2b4d6a8f3adccff5cb49f3</projectId>-->
<!--<branchName>mystic-field</branchName>-->