### PR TITLE
Fix booking UI permissions and add filter options

### DIFF
--- a/src/app/bookings/page.tsx
+++ b/src/app/bookings/page.tsx
@@ -9,7 +9,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Button } from '@/components/ui/button'
 import { useToast } from '@/hooks/use-toast'
 
-const statusOptions: { value: BookingStatus; label: string }[] = [
+const statusOptions: { value: 'all' | BookingStatus; label: string }[] = [
+  { value: 'all', label: 'Tất cả' },
   { value: 'pending', label: 'Chờ xác nhận' },
   { value: 'confirmed', label: 'Đã xác nhận' },
   { value: 'in_progress', label: 'Đang diễn ra' },
@@ -30,7 +31,7 @@ const typeOptions: { value: 'all' | BookingType; label: string }[] = [
 export default function BookingsPage() {
   const { isAuthenticated, isCreator, isAdmin } = useAuth()
   const role: 'user' | 'creator' | 'admin' = isAdmin() ? 'admin' : (isCreator() ? 'creator' : 'user')
-  const [status, setStatus] = React.useState<BookingStatus>('pending')
+  const [status, setStatus] = React.useState<'all' | BookingStatus>('pending')
   const [type, setType] = React.useState<'all' | BookingType>('all')
   const [bookings, setBookings] = React.useState<Booking[]>([])
   const [loading, setLoading] = React.useState(false)
@@ -41,7 +42,7 @@ export default function BookingsPage() {
     if (!isAuthenticated) return
     setLoading(true)
     try {
-      const opts = { status }
+      const opts = status === 'all' ? {} : { status }
       const res = role === 'creator' || role === 'admin' ? await bookingApi.getCreatorBookings(opts) : await bookingApi.getUserBookings(opts)
       if (res.success && res.data) {
         const raw: any = res.data as any

--- a/src/components/booking/BookingList.tsx
+++ b/src/components/booking/BookingList.tsx
@@ -66,7 +66,7 @@ const statusClass: Record<BookingStatus, string> = {
 const canAccept = (role: RoleKind, status: BookingStatus) => (role !== 'user') && status === 'pending'
 const canReject = (role: RoleKind, status: BookingStatus) => (role !== 'user') && status === 'pending'
 const canComplete = (role: RoleKind, status: BookingStatus) => (role !== 'user') && (status === 'in_progress' || status === 'confirmed')
-const canCancel = (role: RoleKind, status: BookingStatus) => (status === 'pending' || status === 'confirmed')
+const canCancel = (role: RoleKind, status: BookingStatus) => role !== 'creator' && status === 'pending'
 
 function initials(name?: string) {
   if (!name) return 'A'

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -24,6 +24,7 @@ import {
   Heart,
   MessageCircle,
   Shield,
+  Calendar,
 } from 'lucide-react'
 import { useMemo } from 'react'
 import { useRouter } from 'next/navigation'
@@ -191,12 +192,14 @@ export default function Header() {
                       <span>Ví của tôi</span>
                     </Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <Link href="/streams" className="cursor-pointer">
-                      <Zap className="mr-2 h-4 w-4" />
-                      <span>Live Streams</span>
-                    </Link>
-                  </DropdownMenuItem>
+                  {(user?.role === 'creator' || user?.role === 'admin') && (
+                    <DropdownMenuItem asChild>
+                      <Link href="/streams" className="cursor-pointer">
+                        <Zap className="mr-2 h-4 w-4" />
+                        <span>Live Streams</span>
+                      </Link>
+                    </DropdownMenuItem>
+                  )}
                   {user?.role === 'creator' ? (
                     <DropdownMenuItem asChild>
                       <Link href="/stream" className="cursor-pointer">
@@ -216,6 +219,12 @@ export default function Header() {
                     <Link href="/messages" className="cursor-pointer">
                       <MessageCircle className="mr-2 h-4 w-4" />
                       <span>Tin nhắn</span>
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <Link href="/bookings" className="cursor-pointer">
+                      <Calendar className="mr-2 h-4 w-4" />
+                      <span>Booking</span>
                     </Link>
                   </DropdownMenuItem>
                   {user?.role === 'admin' && (


### PR DESCRIPTION
## Purpose
The user requested several improvements to the booking system UI:
1. Restrict Live Streams dropdown menu item to only admin and creator roles (remove from regular users)
2. Add a Booking menu item to the header dropdown since the route exists but wasn't accessible via UI
3. Add an "All" filter option to the booking status filter (currently defaults to pending only)
4. Fix booking action permissions - remove cancel button for approved/rejected/completed bookings, and prevent creators from canceling bookings (only allow approve/reject)

## Code changes
- **Header dropdown**: Added role-based conditional rendering for Live Streams menu item, restricted to creators and admins only
- **Header dropdown**: Added new Booking menu item with Calendar icon for all authenticated users
- **Booking page**: Added "Tất cả" (All) option to status filter and updated logic to handle empty status parameter
- **Booking list**: Updated `canCancel` function to prevent creators from canceling bookings and restrict cancellation to pending status only

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 98`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b60ee85bfa2b4d6a8f3adccff5cb49f3/stellar-sanctuary-1)

👀 [Preview Link](https://b60ee85bfa2b4d6a8f3adccff5cb49f3-stellar-sanctuary-1.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b60ee85bfa2b4d6a8f3adccff5cb49f3</projectId>-->
<!--<branchName>stellar-sanctuary-1</branchName>-->