### PR TITLE
Reduce desktop live stream card height by 1/3

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -302,7 +302,7 @@ function LiveStreamsTab() {
             {liveStreams.map((stream, idx) => (
               <Link key={stream.id} href={`/watch/${stream.id}`}>
                 <Card className="bg-gray-800 border-gray-700 hover:border-red-500/50 transition-colors cursor-pointer group">
-                  <div className="relative aspect-[3/5] sm:aspect-[3/4] overflow-hidden rounded-t-lg">
+                  <div className="relative aspect-[3/5] sm:aspect-[3/4] lg:aspect-[9/8] overflow-hidden rounded-t-lg">
                     <img src={THUMBNAILS[idx % THUMBNAILS.length]} alt={stream.title} className="w-full h-full object-cover" />
 
                     <div className="absolute inset-0 bg-black/10 transition-colors" />


### PR DESCRIPTION
## Purpose
User requested to reduce the height of live stream cards on desktop by 1/3 in the Live tab. The mobile version was already working correctly and didn't need changes.

## Code changes
- Modified the aspect ratio for large screens (lg breakpoint) from `aspect-[3/4]` to `aspect-[9/8]` in the LiveStreamsTab component
- This change reduces the card height on desktop while maintaining the existing aspect ratios for mobile and tablet devices
- Only affects the live stream card thumbnails in the Live tab sectionTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 186`

🔗 [Edit in Builder.io](https://builder.io/app/projects/980ff625e681417f97334074a779d61f/glow-den)

👀 [Preview Link](https://980ff625e681417f97334074a779d61f-glow-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>980ff625e681417f97334074a779d61f</projectId>-->
<!--<branchName>glow-den</branchName>-->