### PR TITLE
Remove duplicate stream buttons and share functionality

### DIFF
--- a/src/app/stream/page.tsx
+++ b/src/app/stream/page.tsx
@@ -271,12 +271,6 @@ export default function StreamPage() {
                     Recording
                   </Badge>
                 )}
-                {currentStream && (
-                  <Button variant="outline" size="sm" onClick={copyStreamLink}>
-                    <Share2 className="w-4 h-4 mr-2" />
-                    Chia sẻ
-                  </Button>
-                )}
               </div>
               <div className="flex items-center space-x-2">
                 {!currentStream ? (

--- a/src/app/stream/page.tsx
+++ b/src/app/stream/page.tsx
@@ -24,8 +24,6 @@ import {
   Mic,
   MicOff,
   VideoOff,
-  Share2,
-  Save,
   Play,
   Square
 } from 'lucide-react'

--- a/src/app/stream/page.tsx
+++ b/src/app/stream/page.tsx
@@ -566,14 +566,6 @@ export default function StreamPage() {
               />
             </div>
             
-            {!currentStream && (
-              <div className="flex justify-end">
-                <Button onClick={handleStartStream} disabled={isStartingStream}>
-                  <Save className="w-4 h-4 mr-2" />
-                  Lưu & Bắt đầu Stream
-                </Button>
-              </div>
-            )}
           </CardContent>
         </Card>
         )}

--- a/src/app/stream/page.tsx
+++ b/src/app/stream/page.tsx
@@ -194,13 +194,6 @@ export default function StreamPage() {
     }
   }
 
-  const copyStreamLink = () => {
-    if (currentStream) {
-      const link = `${window.location.origin}/watch/${currentStream.id}`
-      navigator.clipboard.writeText(link)
-      toast.success('Link stream đã được sao chép!')
-    }
-  }
 
   if (authLoading) {
     return (


### PR DESCRIPTION
## Purpose
Clean up the stream page UI by removing redundant buttons and share functionality as requested. The user identified duplicate "Start Stream" buttons and unnecessary share icon after streaming, requesting their removal to improve the interface.

## Code changes
- Removed duplicate "Save & Start Stream" button from the bottom section
- Removed share button and `copyStreamLink` function that appeared after streaming
- Cleaned up unused imports (`Share2`, `Save` icons)
- Streamlined the stream controls to avoid UI duplicationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 189`

🔗 [Edit in Builder.io](https://builder.io/app/projects/980ff625e681417f97334074a779d61f/flare-verse)

👀 [Preview Link](https://980ff625e681417f97334074a779d61f-flare-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>980ff625e681417f97334074a779d61f</projectId>-->
<!--<branchName>flare-verse</branchName>-->